### PR TITLE
Changes: WebGui, html

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,7 +26,8 @@
   git clone --recursive https://github.com/RedisTimeSeries/RedisTimeSeries.git
   cd RedisTimeSeries
   git checkout -b v1.4.8 v1.4.8
-  make
+  make setup
+  make build
   # copy the library or link to the library
   cp bin/linux-x64-release/redistimeseries.so /your/favorite/path
 ```
@@ -52,6 +53,8 @@
   `N` in option `-jN` is the number of parallel jobs.  
    The installation directory can be configured by `--prefix=` or `-DCMAKE_INSTALL_REFIX=` option.  
 - Install boost  
+  If you want to use  the environment variable `HOME`, it is safe to use `$HOME` or `${HOME}` as the argument to the `b2` command.
+  The `~` character in the `b2` command argument is literally treated as `~ (tilda)`, not as the environment variable `HOME`.   
   The following example shows how to build boost 1.79.0.  
   ```bash
   git clone https://github.com/boostorg/boost.git

--- a/controller/HttpWebSocketServer.cxx
+++ b/controller/HttpWebSocketServer.cxx
@@ -1,6 +1,8 @@
 #include <iostream>
 #include <string>
 
+#include <fairmq/FairMQLogger.h>
+
 #include "controller/listener.h"
 #include "controller/HttpWebSocketServer.h"
 
@@ -35,7 +37,7 @@ void HttpWebSocketServer::Run(std::string_view scheme, std::string_view address,
   // Capture SIGINT and SIGTERM to perform a clean shutdown
   fSignals = std::make_shared<net::signal_set>(*fContext, SIGINT, SIGTERM); 
   fSignals->async_wait([&ioc = *fContext](const beast::error_code &ec, int n){ 
-    std::cout << "Got signal : ec = " << ec.what() << ", n = " << n << std::endl;
+    LOG(fatal) << "Got signal : ec = " << ec.what() << ", n = " << n;
     ioc.stop(); 
   });
 

--- a/controller/beast_tools.cxx
+++ b/controller/beast_tools.cxx
@@ -1,11 +1,14 @@
+#include <iostream>
+
+#include <fairmq/FairMQLogger.h>
+
 #include "controller/beast_tools.h"
 
-#include <iostream>
 
 //_____________________________________________________________________________
 void fail(beast::error_code ec, char const* what)
 {
-    std::cerr << what << ": " << ec.message() << "\n";
+    LOG(warn) << "boost::beast fail(): what = " << what << ": ec.message() = " << ec.message();
 }
 
 //_____________________________________________________________________________

--- a/controller/http_session.cxx
+++ b/controller/http_session.cxx
@@ -1,3 +1,5 @@
+#include <fairmq/FairMQLogger.h>
+
 #include "controller/websocket_session.h"
 #include "controller/http_session.h"
 
@@ -57,16 +59,15 @@ void http_session::on_read(beast::error_code ec, std::size_t bytes_transferred)
 
   // This means they closed the connection
   if(ec == http::error::end_of_stream) {
-    //std::cout << __FILE__ << ":" << __LINE__  << " " << __func__ << " " << ec.what() << std::endl;
+    LOG(warn)  << "boost::beast http session: what = " << ec.what() << std::endl;
     return do_close();
   }
 
   if(ec) {
-    //std::cout << __FILE__ << ":" << __LINE__  << " " << __func__ << " " << ec.what() << std::endl;
     return fail(ec, "http read");
   }
 
-  std::cout << " parser_->get() " << parser_->get() << std::endl;
+  LOG(debug) << " parser_->get() " << parser_->get();
   // See if it is a WebSocket Upgrade
   if(websocket::is_upgrade(parser_->get())) {
     // Create a websocket session, transferring ownership
@@ -111,6 +112,7 @@ void http_session::do_close()
 {
   // Send a TCP shutdown
   beast::error_code ec;
+  LOG(debug) << "boost::beast http session: Send a TCP shutdown";
   stream_.socket().shutdown(tcp::socket::shutdown_send, ec);
 
   // At this point the connection is closed gracefully

--- a/controller/websocket_session.cxx
+++ b/controller/websocket_session.cxx
@@ -1,6 +1,8 @@
 #include <algorithm>
 #include <mutex>
 
+#include <fairmq/FairMQLogger.h>
+
 #include "controller/WebSocketHandle.h"
 #include "controller/websocket_session.h"
 
@@ -13,7 +15,7 @@ websocket_session::websocket_session(tcp::socket&& socket)
 //_____________________________________________________________________________
 void websocket_session::on_accept(beast::error_code ec)
 {
-  std::cout << __func__ << " : new connection" << std::endl;
+  LOG(debug) << " websocket session : new connection" << std::endl;
   if(ec) {
     return fail(ec, "websocket accept");
   }
@@ -46,13 +48,13 @@ void websocket_session::on_read(beast::error_code ec, std::size_t bytes_transfer
 
   // This indicates that the websocket_session was closed
   if(ec == websocket::error::closed) {
-    //std::cout << __FILE__ << ":" << __LINE__  << " " << __func__ << " " << ec.what() << std::endl;
+    LOG(warn) << "websocket session : " << ec.what();
     OnClose(id_);
     return;
   }
 
   if(ec) {
-    //std::cout << __FILE__ << ":" << __LINE__  << " " << __func__ << " " << ec.what() << std::endl;
+    LOG(warn) << "websocket session : " << ec.what();
     fail(ec, "websocket read");
   }
 

--- a/plugins/Constants.h
+++ b/plugins/Constants.h
@@ -9,6 +9,8 @@ namespace daq::service {
 static constexpr std::string_view TopPrefix{"daq_service"};
 static constexpr std::string_view PresencePrefix{"presence"};
 static constexpr std::string_view HealthPrefix{"health"};
+static constexpr std::string_view FairMQStatePrefix{"fair-mq-state"};
+static constexpr std::string_view UpdateTimePrefix{"updatedTime"};
 static constexpr std::string_view ProgOptionPrefix{"option"};
 static constexpr std::string_view ServiceInstanceIndexPrefix{"service-instance-index"};
 

--- a/plugins/DaqServicePlugin.h
+++ b/plugins/DaqServicePlugin.h
@@ -73,7 +73,6 @@ public:
 private:
   void ChangeDeviceStateByMultiCommand(std::string_view cmd);
   void ChangeDeviceStateBySingleCommand(std::string_view cmd);
-  void PublishDaqState(std::string_view state, std::string_view lastChecked);
   void ReadRunNumber();
   void Register();
   void ResetTtl(); 
@@ -102,6 +101,8 @@ private:
   //std::string fSeparator;
   std::unique_ptr<Presence> fPresence;
   std::unique_ptr<Health> fHealth;
+  std::string fFairMQStateKey;
+  std::string fUpdateTimeKey;
   std::string fProgOptionKeyName;
   long long fMaxTtl;
   long long fTtlUpdateInterval;

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,14 +26,30 @@ Each Sampler sends data to one Sink with the same instance index.
   ./topology-1-1.sh
 ```
 
+```mermaid
+graph LR
+  Sampler-0 --> Sink-0
+  Sampler-1 --> Sink-1
+  Sampler-2 --> Sink-2
+```
+
 ## topology-n-n-m.sh
 A simple topology of _N_-**Sampler**s, _N_-**fairmq-splitter**s, and _M_-**Sink**s with the **PUSH-PULL** pattern. 
 Each Sampler sends data to one fairmq-splitter with the same instance index. 
-Then, the fairmq-splitter sends the data to a Sink. 
+Then, the fairmq-splitter sends the data to Sinks. 
+The `autoSubChannel true` flag is used to give each sub-socket a different `address:port` and to distinguish them by index.
 The fairmq-splitter determines the destination by the number of messages sent in a round-robin fashion.
 
 ```bash
   ./topology-n-n-m.sh
+```
+
+```mermaid
+graph LR
+  Sampler-0 --> fairmq-splitter-0
+  Sampler-1 --> fairmq-splitter-1
+  Sampler-2 --> fairmq-splitter-2
+  fairmq-splitter-0 & fairmq-splitter-1 & fairmq-splitter-2  --> Sink-0 & Sink-1
 ```
 
 ## mq-param.sh

--- a/share/controller/daq-webctl.html
+++ b/share/controller/daq-webctl.html
@@ -74,15 +74,14 @@
     </p>
     
     <h2>State Summary</h2>
-      <input type="button" onclick="redis_publish('get_state')" value="Get" data-toggle="tool-tip" title="Get instance list and state via redis-pubsub">
-      <input type="button" onclick="ResetStateList()" value="Reset" data-toggle="tool-tip" title="Reset instance list and state (for shrinking list)">
     <p id="State Summary"></p>
+      <input type="button" id="buttonInstanceTable" onclick="ToggleInstanceTable(this)" value="Show details" data-toggle="tool-tip" title="Show instance state table">
     <p id="Instance State"></p>
 
     <h2>Select command target</h2>
     <p id="commandTarget"> 
-      <select  id="commandTargetServiceSelect"  onChange="SendSelectedResult('commandTargetServiceSelect')"  multiple size=10></select>
-      <select  id="commandTargetInstanceSelect" onChange="SendSelectedResult('commandTargetInstanceSelect')" multiple size=10></select>
+      <select  id="serviceSelector"  multiple size=10></select>
+      <select  id="instanceSelector"  multiple size=10></select>
     </p>
    
     
@@ -105,8 +104,6 @@
     // -------------- table --------------------
     const instStateTable    = CreateInstanceStateTable();
     const stateSummaryTable = CreateStateSummaryTable();
-    const stateList    = new Array();
-    const stateSummary = new Array();
 
     // --------------- websocket ---------------
     let path = window.location.href;
@@ -120,7 +117,6 @@
     socket.onopen = function() {
        console.log('websocket initialized');
        this._ready = true;
-       redis_publish('get_state');
     }
 
     socket.onmessage = function(e) {
@@ -129,7 +125,7 @@
          const s = "unsupported message kind: " + (typeof msg);
          console.log(s);
          alert(s);
-         return 
+         return;
        } else {
          if (msg.startsWith('error:')) {
            alert(msg);
@@ -138,8 +134,9 @@
          } else if (msg.startsWith('WebSocket Connected ID:')) {
            UpdateWebSocketConnectedIdList(msg);
          } else {
+           //console.log(msg);
            const obj = JSON.parse(msg);
-           //console.log(obj.type);
+           //console.log('obj.type : ' + obj.type);
 
            if (obj.type=='error') {
             alert(obj.value);
@@ -147,16 +144,8 @@
             SetRunNumber(obj.value);
            } else if (obj.type=='set latest_run_number') {
             SetLatestRunNumber(obj.value); 
-           } else if (obj.type=='state-summary') {
-            UpdateStateSummary(obj);
-            //SendSelectedResult('commandTargetServiceSelect');
-           } else if (obj.type=='instance-state') {
-            UpdateInstanceState(obj);
-            //SendSelectedResult('commandTargetInstanceSelect');
-           } else if (obj.type=='selected services') {
-            UpdateTargetServices(obj);
-           } else if (obj.type=='selected instances') {
-            UpdateTargetInstances(obj);
+           } else if (obj.type=='state-summary-table') {
+            UpdateSummaryTable(obj);
            }
           
            //AddOutput("txt: " + msg);
@@ -311,15 +300,28 @@
     
     // --------------------------------------------------
     function redis_publish(arg) {
-      SendMessage('{ "command": "redis-publish", "value": "' + arg + '" }');
+      //console.log(this.constructor.name + ': arg = ' + arg);
+      const serviceOptions  = document.getElementById('serviceSelector'); 
+      const srv = [];
+      for (let i=0; i< serviceOptions.length; i++) {
+        if (serviceOptions[i].selected) {
+          srv.push(serviceOptions[i].text);
+        }
+      }
+      const instOptions  = document.getElementById('instanceSelector'); 
+      const inst = [];
+      for (let i=0; i< instOptions.length; i++) {
+        if (instOptions[i].selected) {
+          inst.push(instOptions[i].text);
+        }
+      }
+
+      const cmd = { command: 'redis-publish', value: arg, services: srv, instances: inst };
+      const msg = JSON.stringify(cmd);
+      console.log(this.constructor.name + ': msg = ' + msg);
+      SendMessage(msg);
     }
 
-
-    // --------------------------------------------------
-    function ResetStateList() {
-      SendMessage('{ "command": "resetStateList" }');
-      redis_publish('get_state');
-    }
 
     // --------------------------------------------------
     function SendMessage(arg) {
@@ -327,23 +329,6 @@
        if (socket) {
           socket.send(arg);
        }
-    }
-    // --------------------------------------------------
-    function SendSelectedResult(arg) {
-      //console.log(this.constructor.name + ': arg = ' + arg);
-      const sel  = document.getElementById(arg); 
-      const arr = [];
-      for (let i=0; i< sel.length; i++) {
-        if (sel[i].selected) {
-          arr.push(sel[i].text);
-        }
-      }
-      const msg = { command: arg };
-      msg["items"] = arr;
-      const s = JSON.stringify(msg);
-      //console.log(this.constructor.name + ': selected = ' + arr);
-      //console.log('SendSelectedResult: ' + s);
-      SendMessage(s);
     }
 
     // --------------------------------------------------
@@ -377,93 +362,34 @@
     }
     
     // --------------------------------------------------
-    function UpdateInstanceState(arg) {
-      // -- -- -- -- -- -- -- -- 
-      // update object list
-      // -- -- -- -- -- -- -- -- 
-      const long_name = arg.service + ':' + arg.instance;
-      const index = stateList.findIndex((e) => (e.long_name === long_name));
-      //console.log('UpdateInstanceState: index = ' + index + ' ' + long_name);
-      if (index < 0) {
-        const obj = { long_name: long_name, service: arg.service, instance: arg.instance, state: arg.state, date: arg.date };
-        stateList.push(obj);
-        //const new_row = instStateTable.insertRow(-1);
-        //for (let i=0; i<4; ++i) {
-        //  new_row.insertCell(-1);
-        //}
+    function ToggleInstanceTable(arg) {
+      if (arg.value == "Hide details") {
+        arg.value = "Show details";
       } else {
-        const obj = stateList[index];
-        obj.state = arg.state;
-        obj.date  = arg.date;
+        arg.value = "Hide details";
       }
 
-      // sort list by long_name
-      stateList.sort(function (a, b) {
-        if (a.long_name > b.long_name) { 
-          return 1;
-        } else {
-          return -1;
-        }
-      });
-      // -- -- -- -- -- -- -- -- 
-      // update HTML table contents
-      // -- -- -- -- -- -- -- -- 
-      //for (let i=0; i<stateList.length; ++i) {
-      //  const obj = stateList[i];
-      //  const row = instStateTable.rows[i+1]; // rows[0] == thead 
-      //  const c = row.cells;
-      //  c[0].innerHTML = obj.service;
-      //  c[1].innerHTML = obj.instance; // short name
-      //  c[2].innerHTML = obj.state;
-      //  c[3].innerHTML = obj.date;
-      //}
-
-      const v = new Array(); 
-      for (let i=0; i<stateList.length; ++i) {
-        v.push({ name: stateList[i].service + ':' + stateList[i].instance });
-      }
-      const o = { instances: v };
-      UpdateTargetInstances(o);
     }
 
     // --------------------------------------------------
-    function UpdateStateSummary(arg) {
-
-      // -- -- -- -- -- -- -- -- --
-      // update object list
-      // -- -- -- -- -- -- -- -- --
-      const index = stateSummary.findIndex((e) => (e.service === arg.service));
-      //console.log('UpdateStateSummary: index = ' + index + ' ' + arg.service);
-      if (index < 0) {
-        const obj = { service: arg.service, date: arg.date, n_instances: arg.n_instances, counts: arg.counts };
-        stateSummary.push(obj);
-        const new_row = stateSummaryTable.insertRow(-1);
-        for (let i=0; i<(obj.counts.length+3); i++) {
-          new_row.insertCell(-1);
-        }
-      } else {
-        const obj       = stateSummary[index];
-        obj.date        = arg.date;
-        obj.n_instances = arg.n_instances;
-        obj.counts      = arg.counts;
+    function UpdateSummaryTable(arg) {
+      const services = arg.services;
+     
+      //console.log('UpdateSummaryTable: services.length ' + services.length);
+      //console.log('UpdateSummaryTable: stateSummaryTable.length ' + stateSummaryTable.rows.length);
+      
+      // update state summary 
+      for (let i=stateSummaryTable.rows.length; stateSummaryTable.rows.length>1; --i) {
+        stateSummaryTable.deleteRow(-1);
       }
-
-      // sort list by service name
-      stateSummary.sort(function (a, b) {
-        if (a.service > b.service) {
-          return 1;
-        } else {
-          return -1;
+      for (let i=0; i<services.length; ++i) {
+        const row = stateSummaryTable.insertRow(-1);
+        for (let j=0; j<(services[0].counts.length+3); j++) {
+          row.insertCell(-1);
         }
-      });
-
-      // -- -- -- -- -- -- -- -- --
-      // update table contents
-      // -- -- -- -- -- -- -- -- --
-      for (let i=0; i<stateSummary.length; ++i) {
-        const obj = stateSummary[i];
-        const row = stateSummaryTable.rows[i+1]; // rows[0] == thead
-        const c = row.cells;
+        const obj = services[i];
+        //const row = stateSummaryTable.rows[i+1]; // rows[0] == thead
+        const c   = row.cells;
         c[0].innerHTML = obj.service;
         c[1].innerHTML = obj.n_instances;
         for (let j=0; j<obj.counts.length; ++j) {
@@ -473,12 +399,49 @@
         c[obj.counts.length+2].innerHTML = obj.date;
       }
 
-      const v = new Array(); 
-      for (let i=0; i<stateSummary.length; ++i) {
-        v.push({ name: stateSummary[i].service });
+      // update instance state table
+      for (let i=instStateTable.rows.length; instStateTable.rows.length>1; --i) {
+        instStateTable.deleteRow(-1);
       }
-      const o = { services: v };
-      UpdateTargetServices(o);
+      const btnVal = document.getElementById('buttonInstanceTable').value;
+      // The value of 'btnVal' corresponds to the next show/hide tate. 
+      // i.e. The current value means the opposite of the show/hide state. 
+      if (btnVal === 'Hide details') { 
+        for (let i=0; i<services.length; ++i) {
+          const srv = services[i];
+          for (let j=0; j<srv.instances.length; ++j) {
+            const row = instStateTable.insertRow(-1);
+            for (let i=0; i<4; ++i) {
+              row.insertCell(-1);
+            }
+            const obj = srv.instances[j];
+            const c = row.cells;
+            c[0].innerHTML = obj.service;
+            c[1].innerHTML = obj.instance;
+            c[2].innerHTML = obj.state;
+            c[3].innerHTML = obj.date;
+          }
+        }
+      } 
+
+      // rename field: service -> name
+      const srvArray = new Array(); 
+      for (let i=0; i<services.length; ++i) {
+        srvArray.push({ name: services[i].service });
+      }
+      const srvObj = { services: srvArray, changed: arg.service_list_changed };
+      UpdateTargetServices(srvObj);
+      
+      const instArray = new Array();
+      let instChanged = arg.instance_list_changed;
+      for (let i=0; i<services.length; ++i)  {
+        const srv = services[i];
+        for (let j=0; j<srv.instances.length; ++j) {
+          instArray.push({ name: srv.service + ':' + srv.instances[j].instance });
+        }
+      }
+      const instObj = { instances: instArray, changed: instChanged };
+      UpdateTargetInstances(instObj);
     }
 
     // --------------------------------------------------
@@ -487,7 +450,12 @@
       // update HTML selection list
       // -- -- -- -- -- -- -- -- 
       // clear selection list
-      const sel = document.getElementById("commandTargetInstanceSelect");
+      const sel = document.getElementById("instanceSelector");
+      if (sel.options.length>0) {
+      if  (arg.changed === 'false') {
+        return;
+      }
+      }
       while (sel.lastChild) {
         sel.removeChild(sel.lastChild);
       }
@@ -518,8 +486,14 @@
       // -- -- -- -- -- -- -- -- --
       // update selection list
       // -- -- -- -- -- -- -- -- --
+
       // clear selection list
-      const sel = document.getElementById("commandTargetServiceSelect");
+      const sel = document.getElementById("serviceSelector");
+      if (sel.options.length>0) {
+        if  (arg.changed === 'false') {
+          return;
+        }
+      }
       while (sel.lastChild) {
         sel.removeChild(sel.lastChild);
       }


### PR DESCRIPTION
- Changes
  -  WebGui
      - Add `fair-mq-state` and `updatedTime` keys to daq_service redis-db
      - Remove member variables to keep the contents (daq state) of the redis server 
      - Change WebGui to use FairMQLogger instead of cout
  - html 
    - Add toggle button to show/hide details of the instance state table 
- Add mermaid graphs to explain the example topology in scripts/README.md
- Fix #9
- Fix #8