### PR TITLE
bug fix DaqServicePlugin.cxx

### DIFF
--- a/plugins/DaqServicePlugin.cxx
+++ b/plugins/DaqServicePlugin.cxx
@@ -1011,13 +1011,13 @@ void Plugin::SubscribeToDaqCommand()
         } else {
           ChangeDeviceStateByMultiCommand(*val);
         }
-      }
-
-      // any state Exiting by exiting SubscribeToDaqCommand() and calling RunShutdownSequence() in the state control thread 
-      if ((*val==daq::command::Exit) || 
-          (*val==daq::command::Quit) || 
-          (*val==fairmq::command::End)) {
-        fPluginShutdownRequested = true;
+       
+        // any state Exiting by exiting SubscribeToDaqCommand() and calling RunShutdownSequence() in the state control thread 
+        if ((*val==daq::command::Exit) || 
+            (*val==daq::command::Quit) || 
+            (*val==fairmq::command::End)) {
+          fPluginShutdownRequested = true;
+        }
       }
     }
   });

--- a/share/controller/README.md
+++ b/share/controller/README.md
@@ -13,7 +13,8 @@ A simple html (and JavaScript) used by `daq-webctl`.
 
 ```
 
-After starting `daq-webctl`, open the URL `http://localhost:8080/daq-webctl.html` in a web browser.   
+After starting `daq-webctl`, open the URL `http://localhost:8080/daq-webctl.html` or `http://localhost:8080/`in a web browser.   
+In the latter case (the path to the HTML file is omitted), the symbolic link to the default file `daq-webctl.html` is used. 
 
 Note:
 - Run number must be set before entering to the Running state. 


### PR DESCRIPTION
bug fix: The `DaqServicePlugin`code so far always accepted the DAQ End- command.