### PR TITLE
update to support multiple version of FairMQ 1.8 and 1.4

### DIFF
--- a/controller/CMakeLists.txt
+++ b/controller/CMakeLists.txt
@@ -45,15 +45,31 @@ target_link_directories(${EXEC} PUBLIC
   ${FairMQ_LIBDIR};
 )
 
-target_link_libraries(${EXEC} PUBLIC
-  ${Boost_LIBRARIES};
-  FairMQStateMachine;
-  FairLogger;
-  ${fmt_LIB};
-  ${HIREDIS_LIB};
-  ${REDIS_PLUS_PLUS_LIB};
-  ${CMAKE_THREAD_LIBS_INIT};
-)
+if ((FairMQ_VERSION VERSION_GREATER_EQUAL 1.8.0)
+  AND (FairMQ_VERSION VERSION_LESS_EQUAL 1.8.9))
+  target_link_libraries(${EXEC} PUBLIC
+    ${Boost_LIBRARIES};
+    fairmq;
+    FairLogger;
+    ${fmt_LIB};
+    ${HIREDIS_LIB};
+    ${REDIS_PLUS_PLUS_LIB};
+    ${CMAKE_THREAD_LIBS_INIT};
+  )
+elseif ((FairMQ_VERSION VERSION_GREATER_EQUAL 1.4.55)
+    AND (FairMQ_VERSION VERSION_LESS_EQUAL 1.4.56))
+  target_link_libraries(${EXEC} PUBLIC
+    ${Boost_LIBRARIES};
+    FairMQStateMachine;
+    FairLogger;
+    ${fmt_LIB};
+    ${HIREDIS_LIB};
+    ${REDIS_PLUS_PLUS_LIB};
+    ${CMAKE_THREAD_LIBS_INIT};
+  )
+else()
+  message(FATAL_ERROR "Unsupported FairMQ version ${FairMQ_VERSION}")
+endif()
 
 install(TARGETS
   ${EXEC};

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -18,12 +18,25 @@ foreach(lvar IN ITEMS Sampler; Sink; NullDevice;)
     ${FairMQ_LIBDIR};
   )
 
-  target_link_libraries(${EXEC} PUBLIC 
-    ${Boost_LIBRARIES};  
-    ${fmt_LIB};
-    FairLogger;
-    FairMQ;
-  )
+  if ((FairMQ_VERSION VERSION_GREATER_EQUAL 1.8.0)
+    AND (FairMQ_VERSION VERSION_LESS_EQUAL 1.8.9))
+    target_link_libraries(${EXEC} PUBLIC 
+      ${Boost_LIBRARIES};  
+      ${fmt_LIB};
+      FairLogger;
+      fairmq;
+    )
+  elseif ((FairMQ_VERSION VERSION_GREATER_EQUAL 1.4.55)
+    AND (FairMQ_VERSION VERSION_LESS_EQUAL 1.4.56))
+    target_link_libraries(${EXEC} PUBLIC 
+      ${Boost_LIBRARIES};  
+      ${fmt_LIB};
+      FairLogger;
+      FairMQ;
+    )
+  else()
+    message(FATAL_ERROR "Unsupported FairMQ version ${FairMQ_VERSION}")
+  endif()
 
   install(TARGETS
     ${EXEC};

--- a/plugins/DaqServicePlugin.cxx
+++ b/plugins/DaqServicePlugin.cxx
@@ -1104,7 +1104,9 @@ void Plugin::WriteProgOptions()
         std::make_pair("shm-mlock-segment",   std::to_string(GetProperty<bool>("shm-mlock-segment"))),
         std::make_pair("shm-zero-segment",    std::to_string(GetProperty<bool>("shm-zero-segment"))),
         std::make_pair("shm-throw-bad-alloc", std::to_string(GetProperty<bool>("shm-throw-bad-alloc"))),
+#if 0 // This option was used, and it is no longer useed in FairMQ 1.8.
         std::make_pair("ofi-size-hint",       std::to_string(GetProperty<std::size_t>("ofi-size-hint"))),
+#endif
         std::make_pair("rate",                std::to_string(GetProperty<float>("rate"))),
         std::make_pair("session",             GetProperty<std::string>("session")),
     })

--- a/plugins/ParameterConfigPlugin.cxx
+++ b/plugins/ParameterConfigPlugin.cxx
@@ -48,7 +48,9 @@ const std::unordered_set<std::string_view> reservedOptionsBool
 
 const std::unordered_set<std::string_view> reservedOptionsSize
 {   "shm-segment-size", //
+#if 0 // This option was not used, and it is no longer used in FairMQ 1.8.
     "ofi-size-hint", //
+#endif
     "color", //
 };
 

--- a/plugins/TelemetryPlugin.cxx
+++ b/plugins/TelemetryPlugin.cxx
@@ -27,7 +27,13 @@ auto TelemetryPluginProgramOptions() -> fair::mq::Plugin::ProgOptions
     using opt = TelemetryPlugin::OptionKey;
     auto options = bpo::options_description(MyClass.data());
     options.add_options()
-    (opt::TelemetrySeverity.data(), bpo::value<std::string>()->default_value(fair::Logger::SeverityName(fair::Severity::trace)),
+    (opt::TelemetrySeverity.data(),
+        bpo::value<std::string>()->default_value(
+#if 1
+	fair::Logger::SeverityName(fair::Severity::trace).data()),
+#else //FairLogger 1.5 changed the class interface of this.
+	fair::Logger::SeverityName(fair::Severity::trace)),
+#endif
      "Log severity level (telemetry): trace, debug, info, state, warn, error, fatal, nolog.");
 
     return options;


### PR DESCRIPTION
To support FairMQ 1.8, CMakeList.txt was modified.
The "ofi-size-hint" was obsolete. The lines of that was removed from DaqServicePlugin.cxx and ParameterConfigPlugin.cxx.
FairLogger later 1.5 changed a interface class of SeverityName from std::string to std::string_view. For this, the SeverityName line of TeremetoryPlugin.cxx has been modified .
Close #41 #42 #43